### PR TITLE
Retain session ID until timeout has elapsed between events

### DIFF
--- a/Sources/SegmentAmplitude/AmplitudeSession.swift
+++ b/Sources/SegmentAmplitude/AmplitudeSession.swift
@@ -39,7 +39,7 @@ public class AmplitudeSession: EventPlugin, iOSLifecycle {
     
     private var sessionTimer: Timer?
     private var sessionID: TimeInterval?
-    private let fireTime = TimeInterval(300)
+    private let fireTime = TimeInterval(60)
     
     public init() { }
     
@@ -115,6 +115,7 @@ public class AmplitudeSession: EventPlugin, iOSLifecycle {
     }
 
     public func applicationWillResignActive(application: UIApplication?) {
+        // Exposed if reacting to lifecycle events is needed
     }
 }
 

--- a/Sources/SegmentAmplitude/AmplitudeSession.swift
+++ b/Sources/SegmentAmplitude/AmplitudeSession.swift
@@ -115,7 +115,6 @@ public class AmplitudeSession: EventPlugin, iOSLifecycle {
     }
 
     public func applicationWillResignActive(application: UIApplication?) {
-        stopTimer()
     }
 }
 
@@ -124,6 +123,7 @@ public class AmplitudeSession: EventPlugin, iOSLifecycle {
 extension AmplitudeSession {
     func insertSession(event: RawEvent) -> RawEvent {
         var returnEvent = event
+        refreshSessionID()
         if var integrations = event.integrations?.dictionaryValue,
            let sessionID = sessionID {
             
@@ -136,15 +136,22 @@ extension AmplitudeSession {
     @objc
     func handleTimerFire(_ timer: Timer) {
         stopTimer()
+    }
+    
+    func refreshSessionID() {
+        if (sessionID == nil || sessionID == -1)
+        {
+            sessionID = Date().timeIntervalSince1970
+        }
         startTimer()
     }
     
     func startTimer() {
+        sessionTimer?.invalidate()
         sessionTimer = Timer(timeInterval: fireTime, target: self,
                              selector: #selector(handleTimerFire(_:)),
                              userInfo: nil, repeats: true)
         sessionTimer?.tolerance = 0.3
-        sessionID = Date().timeIntervalSince1970
         if let sessionTimer = sessionTimer {
             // Use the RunLoop current to avoid retaining self
             RunLoop.current.add(sessionTimer, forMode: .common)

--- a/Sources/SegmentAmplitude/AmplitudeSession.swift
+++ b/Sources/SegmentAmplitude/AmplitudeSession.swift
@@ -39,7 +39,7 @@ public class AmplitudeSession: EventPlugin, iOSLifecycle {
     
     private var sessionTimer: Timer?
     private var sessionID: TimeInterval?
-    private let fireTime = TimeInterval(60)
+    private let fireTime = TimeInterval(300)
     
     public init() { }
     


### PR DESCRIPTION
Amplitude documentation indicated that the session ID should be retained until a period of time had elapsed between events, which was not matched by the existing implementation.