### PR TITLE
feat: add reset() to plugin

### DIFF
--- a/Example/BasicExample/BasicExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/BasicExample/BasicExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,17 @@
         "repositoryURL": "https://github.com/segmentio/analytics-swift",
         "state": {
           "branch": null,
-          "revision": "79fb17a5d4abf8f80e6a0935e57c7df7b670a6c0",
-          "version": "1.4.1"
+          "revision": "51f56b972de8daee251f18fd2c91fa3a33c8d77e",
+          "version": "1.5.2"
+        }
+      },
+      {
+        "package": "JSONSafeEncoder",
+        "repositoryURL": "https://github.com/segmentio/jsonsafeencoder-swift.git",
+        "state": {
+          "branch": null,
+          "revision": "8b70dc8c01b7b041912e30e29d2b488a43f782ac",
+          "version": "1.0.1"
         }
       },
       {
@@ -15,8 +24,8 @@
         "repositoryURL": "https://github.com/segmentio/Sovran-Swift.git",
         "state": {
           "branch": null,
-          "revision": "944c17d7c46bd95fc37f09136cabd172be5b413b",
-          "version": "1.0.3"
+          "revision": "64f3b5150c282a34af4578188dce2fd597e600e3",
+          "version": "1.1.0"
         }
       }
     ]

--- a/Example/BasicExample/BasicExample/BasicExampleApp.swift
+++ b/Example/BasicExample/BasicExample/BasicExampleApp.swift
@@ -23,7 +23,7 @@ var instance: Analytics? = nil
 extension Analytics {
     static var main: Analytics {
         if instance == nil {
-            instance = Analytics(configuration: Configuration(writeKey: "<WRITE_KEY>")
+            instance = Analytics(configuration: Configuration(writeKey: "7O86AjgXwDLHxwXapRDkSFvqRzLA5n1V")
                         .flushAt(3)
                         .trackApplicationLifecycleEvents(true))
             instance?.add(plugin: AmplitudeSession())

--- a/Example/BasicExample/BasicExample/BasicExampleApp.swift
+++ b/Example/BasicExample/BasicExample/BasicExampleApp.swift
@@ -23,7 +23,7 @@ var instance: Analytics? = nil
 extension Analytics {
     static var main: Analytics {
         if instance == nil {
-            instance = Analytics(configuration: Configuration(writeKey: "7O86AjgXwDLHxwXapRDkSFvqRzLA5n1V")
+            instance = Analytics(configuration: Configuration(writeKey: "<WRITE_KEY>")
                         .flushAt(3)
                         .trackApplicationLifecycleEvents(true))
             instance?.add(plugin: AmplitudeSession())

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(
             name: "Segment",
             url: "https://github.com/segmentio/analytics-swift.git",
-            from: "1.4.1"
+            from: "1.5.2"
         )
     ],
     targets: [

--- a/Sources/SegmentAmplitude/AmplitudeSession.swift
+++ b/Sources/SegmentAmplitude/AmplitudeSession.swift
@@ -66,20 +66,22 @@ public class AmplitudeSession: EventPlugin, iOSLifecycle {
             return event
         }
         
-        lastEventFiredTime = Date()
-        
         var result: T? = event
         switch result {
         case let r as IdentifyEvent:
             result = self.identify(event: r) as? T
+            lastEventFiredTime = Date()
         case let r as TrackEvent:
             result = self.track(event: r) as? T
         case let r as ScreenEvent:
             result = self.screen(event: r) as? T
+            lastEventFiredTime = Date()
         case let r as AliasEvent:
             result = self.alias(event: r) as? T
+            lastEventFiredTime = Date()
         case let r as GroupEvent:
             result = self.group(event: r) as? T
+            lastEventFiredTime = Date()
         default:
             break
         }
@@ -87,6 +89,10 @@ public class AmplitudeSession: EventPlugin, iOSLifecycle {
     }
     
     public func track(event: TrackEvent) -> TrackEvent? {
+        if event.event != "Application Opened" {
+            lastEventFiredTime = Date()
+        }
+        
         guard let returnEvent = insertSession(event: event) as? TrackEvent else {
             return nil
         }

--- a/Sources/SegmentAmplitude/AmplitudeSession.swift
+++ b/Sources/SegmentAmplitude/AmplitudeSession.swift
@@ -121,6 +121,10 @@ public class AmplitudeSession: EventPlugin, iOSLifecycle {
         return returnEvent
     }
     
+    public func reset() {
+         sessionID = nil
+    }
+    
     public func applicationWillEnterForeground(application: UIApplication?) {
         if Date().timeIntervalSince(lastEventFiredTime) >= minSessionTime {
             sessionID = Date().timeIntervalSince1970


### PR DESCRIPTION
- sets `sessionID` to `nil` when `analytics.reset()` is called 
- updates `analytics-swift` in example app to `1.5.2` 