### PR TITLE
Configurable destination

### DIFF
--- a/Sources/SegmentAmplitude/AmplitudeDestination.swift
+++ b/Sources/SegmentAmplitude/AmplitudeDestination.swift
@@ -1,0 +1,50 @@
+//
+//  AmplitudeDestination.swift
+//
+//  Created by Ivan Rapoport on 4/18/24.
+//
+
+// MIT License
+//
+// Copyright (c) 2021 Segment
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+
+import Foundation
+
+public enum AmplitudeDestination {
+    case amplitude
+    case amplitudeActions
+    case custom(String)
+}
+
+extension AmplitudeDestination {
+
+    var key: String {
+        switch self {
+        case .amplitude:
+            "Amplitude"
+        case .amplitudeActions:
+            "Actions Amplitude"
+        case .custom(let key):
+            key
+        }
+    }
+}

--- a/Sources/SegmentAmplitude/AmplitudeSession.swift
+++ b/Sources/SegmentAmplitude/AmplitudeSession.swift
@@ -36,7 +36,9 @@ public class ObjCAmplitudeSession: NSObject, ObjCPlugin, ObjCPluginShim {
 }
 
 public class AmplitudeSession: EventPlugin, iOSLifecycle {
-    public var key = "Actions Amplitude"
+    public var key: String {
+        destination.key
+    }
     public var type = PluginType.enrichment
     public weak var analytics: Analytics?
     
@@ -45,12 +47,11 @@ public class AmplitudeSession: EventPlugin, iOSLifecycle {
     private var sessionID: TimeInterval?
     private var lastEventFiredTime = Date()
     private var minSessionTime: TimeInterval = 5 * 60
-    
-    public init() {
-        if (sessionID == nil || sessionID == -1)
-        {
-            sessionID = Date().timeIntervalSince1970
-        }
+    private var destination: AmplitudeDestination
+
+    public init(destination: AmplitudeDestination = .amplitudeActions) {
+        self.destination = destination
+        sessionID = Date().timeIntervalSince1970
     }
     
     public func update(settings: Settings, type: UpdateType) {


### PR DESCRIPTION
Motivation:

Currently `AmplitudeSession` gets initialized with `Actions Amplitude`, forcing users that use `Amplitude` destinagiton on Segment to change the key after initializing the `AmplitudeSession` object. As the key is not supposed to change during application lifeccycle, it results cleaner to have it as part of the initializer as constants values to avoid issues with typos.

This PR includes:

* Added `AmplitudeDestination` to provide the destination Key
* Added `destination: AmplitudeDestination` parameter to `AmplitudeSession` initializer
* Updated `key` attribute to a computed property that returns the destination key