### PR TITLE
Update README: update deprecated .package() call

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@ Open your Package.swift file and add the following do your the `dependencies` se
 
 ```
 .package(
-            name: "Segment",
-            url: "https://github.com/segment-integrations/analytics-swift-amplitude.git",
-            from: "1.1.3"
-        ),
+    url: "https://github.com/segment-integrations/analytics-swift-amplitude.git",
+    from: "1.4.2"
+)
 ```
 
 


### PR DESCRIPTION
Small update to README to use non-deprecated `.package(...)` call.