### PR TITLE
fix: bump tvOS minimum target to 13.0 to match analytics-swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "SegmentAmplitude",
     platforms: [
         .iOS("13.0"),
-        .tvOS("11.0"),
+        .tvOS("13.0"),
         .watchOS("7.1"),
         .macOS(.v10_15)
     ],


### PR DESCRIPTION
## Summary
- Bumps `tvOS` minimum deployment target from `11.0` to `13.0` in `Package.swift` to match `analytics-swift`

## Motivation
Customers building Swift packages that depend on both `analytics-swift` (tvOS 13.0) and this package (tvOS 11.0) get a build failure because SPM requires all packages in the dependency graph to agree on a minimum platform version. Aligning to `13.0` resolves the conflict.

## Changes
- `Package.swift`: `.tvOS("11.0")` → `.tvOS("13.0")`